### PR TITLE
Add Remix Sudoku solver with animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# -sudoku_v1
+# Sudoku Remix App
+
+This project demonstrates a simple Sudoku solver built with [Remix](https://remix.run/), styled using [Tailwind CSS](https://tailwindcss.com/) and animated with [Framer Motion](https://www.framer.com/motion/).
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+The app shows a Sudoku puzzle solved on load with each cell animated.

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,0 +1,24 @@
+import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+import styles from "./tailwind.css";
+
+export const links: LinksFunction = () => [{ rel: "stylesheet", href: styles }];
+
+export const meta: MetaFunction = () => ({ charset: "utf-8", title: "Sudoku", viewport: "width=device-width,initial-scale=1" });
+
+export default function App() {
+  return (
+    <html lang="en" className="h-full">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body className="h-full">
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,0 +1,44 @@
+import type { LoaderArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { motion } from "framer-motion";
+import { solveSudoku } from "../utils/sudoku";
+
+export const loader = async ({}: LoaderArgs) => {
+  const puzzle = [
+    [5,3,0,0,7,0,0,0,0],
+    [6,0,0,1,9,5,0,0,0],
+    [0,9,8,0,0,0,0,6,0],
+    [8,0,0,0,6,0,0,0,3],
+    [4,0,0,8,0,3,0,0,1],
+    [7,0,0,0,2,0,0,0,6],
+    [0,6,0,0,0,0,2,8,0],
+    [0,0,0,4,1,9,0,0,5],
+    [0,0,0,0,8,0,0,7,9],
+  ];
+  const solved = solveSudoku(puzzle.map(row => [...row]));
+  return json({ solved });
+};
+
+export default function Index() {
+  const { solved } = useLoaderData<typeof loader>();
+  if (!solved) return <div>Unable to solve puzzle</div>;
+  return (
+    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <div className="grid grid-cols-9 gap-1">
+        {solved.map((row, rowIndex) =>
+          row.map((num, colIndex) => (
+            <motion.div
+              key={`${rowIndex}-${colIndex}`}
+              className="w-8 h-8 flex items-center justify-center bg-white border border-gray-300"
+              animate={{ scale: [0.5, 1], opacity: [0, 1] }}
+              transition={{ duration: 0.3, delay: (rowIndex * 9 + colIndex) * 0.03 }}
+            >
+              {num}
+            </motion.div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/utils/sudoku.ts
+++ b/app/utils/sudoku.ts
@@ -1,0 +1,37 @@
+export type Board = number[][];
+
+export const isValidNumber = (board: Board, row: number, col: number, num: number): boolean => {
+  const rowValid = !board[row].includes(num);
+  const colValid = !board.some(r => r[col] === num);
+  const startRow = Math.floor(row / 3) * 3;
+  const startCol = Math.floor(col / 3) * 3;
+  const boxValid = !board
+    .slice(startRow, startRow + 3)
+    .some(r => r.slice(startCol, startCol + 3).includes(num));
+  return rowValid && colValid && boxValid;
+};
+
+export const findEmpty = (board: Board): [number, number] | null => {
+  for (let r = 0; r < 9; r++) {
+    for (let c = 0; c < 9; c++) {
+      if (board[r][c] === 0) return [r, c];
+    }
+  }
+  return null;
+};
+
+export const solveSudoku = (board: Board): Board | null => {
+  const empty = findEmpty(board);
+  if (!empty) return board;
+  const [row, col] = empty;
+
+  for (let num = 1; num <= 9; num++) {
+    if (isValidNumber(board, row, col, num)) {
+      board[row][col] = num;
+      const solved = solveSudoku(board);
+      if (solved) return solved;
+      board[row][col] = 0;
+    }
+  }
+  return null;
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sudoku-remix",
+  "private": true,
+  "scripts": {
+    "build": "remix build",
+    "dev": "remix dev",
+    "start": "remix-serve build"
+  },
+  "dependencies": {
+    "@remix-run/node": "^1.19.0",
+    "@remix-run/react": "^1.19.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.12.16"
+  },
+  "devDependencies": {
+    "@remix-run/dev": "^1.19.0",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.0.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/remix.config.js
+++ b/remix.config.js
@@ -1,0 +1,7 @@
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  appDirectory: "app",
+  serverBuildDirectory: "build",
+  publicPath: "/build/",
+  serverModuleFormat: "cjs"
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./app/**/*.{ts,tsx,jsx,js}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["app/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a minimal Remix app
- implement Sudoku solver in functional TypeScript
- animate puzzle cells with Framer Motion
- wire TailwindCSS for styling and document the steps in the README

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@remix-run/node')*

------
https://chatgpt.com/codex/tasks/task_e_6846c200283083269c8d01e4a0bcb762