### PR TITLE
Rewrite Sudoku app using React hooks

### DIFF
--- a/app/components/SudokuBoard.tsx
+++ b/app/components/SudokuBoard.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import type { Board } from "../utils/sudoku";
+import { generatePuzzle, isSolved } from "../utils/sudoku";
+
+const animals = ["🐱","🐶","🐭","🐹","🐰","🦊","🐻","🐼","🐨","🐯"];
+
+export default function SudokuBoard() {
+  const [puzzle, setPuzzle] = useState<Board | null>(null);
+  const [message, setMessage] = useState("");
+
+  const startGame = (level: number) => {
+    const empties = 20 + level * 5;
+    const { puzzle } = generatePuzzle(empties);
+    setPuzzle(puzzle);
+    setMessage("");
+  };
+
+  const updateCell = (row: number, col: number, value: string) => {
+    if (!puzzle) return;
+    const num = parseInt(value);
+    const next = puzzle.map((r) => r.slice());
+    next[row][col] = isNaN(num) ? 0 : num;
+    setPuzzle(next);
+  };
+
+  const checkBoard = () => {
+    if (!puzzle) return;
+    if (isSolved(puzzle)) setMessage("완성! 축하합니다!");
+    else setMessage("아직 완성되지 않았어요.");
+  };
+
+  return (
+    <div className="flex flex-col items-center space-y-4 py-6 text-center">
+      <h1 className="text-2xl font-bold">귀여운 스도쿠</h1>
+      <div>
+        <p>난이도를 선택하세요:</p>
+        <div className="flex flex-wrap justify-center gap-1 mt-1">
+          {animals.map((a, i) => (
+            <button
+              key={i}
+              title={`난이도 ${i + 1}`}
+              className="px-2 py-1 bg-green-600 text-white rounded"
+              onClick={() => startGame(i + 1)}
+            >
+              {a}
+            </button>
+          ))}
+        </div>
+      </div>
+      {puzzle && (
+        <>
+          <div className="grid grid-cols-9 gap-1 mt-4">
+            {puzzle.map((row, r) =>
+              row.map((cell, c) =>
+                cell !== 0 ? (
+                  <div
+                    key={`${r}-${c}`}
+                    className="w-8 h-8 flex items-center justify-center border bg-gray-100 font-bold"
+                  >
+                    {cell}
+                  </div>
+                ) : (
+                  <input
+                    key={`${r}-${c}`}
+                    className="w-8 h-8 text-center border"
+                    maxLength={1}
+                    value={cell === 0 ? "" : cell}
+                    onChange={(e) =>
+                      updateCell(r, c, e.target.value.replace(/[^1-9]/g, ""))
+                    }
+                  />
+                )
+              )
+            )}
+          </div>
+          <button
+            className="mt-4 px-4 py-2 bg-green-600 text-white rounded"
+            onClick={checkBoard}
+          >
+            정답 확인
+          </button>
+        </>
+      )}
+      <p className="font-bold h-5">{message}</p>
+    </div>
+  );
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,44 +1,10 @@
-import type { LoaderArgs } from "@remix-run/node";
-import { json } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
-import { motion } from "framer-motion";
-import { solveSudoku } from "../utils/sudoku";
-
-export const loader = async ({}: LoaderArgs) => {
-  const puzzle = [
-    [5,3,0,0,7,0,0,0,0],
-    [6,0,0,1,9,5,0,0,0],
-    [0,9,8,0,0,0,0,6,0],
-    [8,0,0,0,6,0,0,0,3],
-    [4,0,0,8,0,3,0,0,1],
-    [7,0,0,0,2,0,0,0,6],
-    [0,6,0,0,0,0,2,8,0],
-    [0,0,0,4,1,9,0,0,5],
-    [0,0,0,0,8,0,0,7,9],
-  ];
-  const solved = solveSudoku(puzzle.map(row => [...row]));
-  return json({ solved });
-};
+import SudokuBoard from "../components/SudokuBoard";
 
 export default function Index() {
-  const { solved } = useLoaderData<typeof loader>();
-  if (!solved) return <div>Unable to solve puzzle</div>;
   return (
     <div className="min-h-screen bg-gray-100 flex items-center justify-center">
-      <div className="grid grid-cols-9 gap-1">
-        {solved.map((row, rowIndex) =>
-          row.map((num, colIndex) => (
-            <motion.div
-              key={`${rowIndex}-${colIndex}`}
-              className="w-8 h-8 flex items-center justify-center bg-white border border-gray-300"
-              animate={{ scale: [0.5, 1], opacity: [0, 1] }}
-              transition={{ duration: 0.3, delay: (rowIndex * 9 + colIndex) * 0.03 }}
-            >
-              {num}
-            </motion.div>
-          ))
-        )}
-      </div>
+      <SudokuBoard />
     </div>
   );
 }
+

--- a/app/utils/sudoku.ts
+++ b/app/utils/sudoku.ts
@@ -1,5 +1,82 @@
 export type Board = number[][];
 
+export const shuffle = <T,>(arr: T[]): T[] => {
+  const res = arr.slice();
+  for (let i = res.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [res[i], res[j]] = [res[j], res[i]];
+  }
+  return res;
+};
+
+export const generateCompletedBoard = (): Board => {
+  const base = 3;
+  const side = base * base;
+
+  const rows = shuffle([...Array(side).keys()]);
+  const cols = shuffle([...Array(side).keys()]);
+  const nums = shuffle([...Array(side).keys()].map((n) => n + 1));
+
+  const board = Array.from({ length: side }, () => Array(side).fill(0));
+
+  for (let r = 0; r < side; r++) {
+    for (let c = 0; c < side; c++) {
+      const value = nums[(base * (r % base) + Math.floor(r / base) + c) % side];
+      board[r][c] = value;
+    }
+  }
+
+  const shuffled = Array.from({ length: side }, (_, r) =>
+    Array.from({ length: side }, (_, c) => board[rows[r]][cols[c]])
+  );
+
+  return shuffled;
+};
+
+export const generatePuzzle = (
+  empties: number
+): { puzzle: Board; solution: Board } => {
+  const solution = generateCompletedBoard();
+  const puzzle = solution.map((row) => row.slice());
+  let removed = 0;
+  while (removed < empties) {
+    const r = Math.floor(Math.random() * 9);
+    const c = Math.floor(Math.random() * 9);
+    if (puzzle[r][c] !== 0) {
+      puzzle[r][c] = 0;
+      removed++;
+    }
+  }
+  return { puzzle, solution };
+};
+
+export const isValidPlacement = (
+  board: Board,
+  row: number,
+  col: number,
+  num: number
+): boolean => {
+  for (let i = 0; i < 9; i++) {
+    if (i !== col && board[row][i] === num) return false;
+    if (i !== row && board[i][col] === num) return false;
+    const boxRow = Math.floor(row / 3) * 3 + Math.floor(i / 3);
+    const boxCol = Math.floor(col / 3) * 3 + (i % 3);
+    if (boxRow !== row && boxCol !== col && board[boxRow][boxCol] === num)
+      return false;
+  }
+  return true;
+};
+
+export const isSolved = (board: Board): boolean => {
+  for (let r = 0; r < 9; r++) {
+    for (let c = 0; c < 9; c++) {
+      const val = board[r][c];
+      if (!val || !isValidPlacement(board, r, c, val)) return false;
+    }
+  }
+  return true;
+};
+
 export const isValidNumber = (board: Board, row: number, col: number, num: number): boolean => {
   const rowValid = !board[row].includes(num);
   const colValid = !board.some(r => r[col] === num);


### PR DESCRIPTION
## Summary
- add sudoku puzzle generators and validators
- build SudokuBoard React component with hooks
- use the new component in the index route

## Testing
- `npm run build` *(fails: remix not found)*
- `yarn build` *(fails: network access restricted)*

------
https://chatgpt.com/codex/tasks/task_e_6846d1157ef08326958cb26ca947c8a0