### PR TITLE
Add animated keypad popup for cell input

### DIFF
--- a/script.js
+++ b/script.js
@@ -181,9 +181,10 @@ function showPopup(input, r, c) {
     if (isValid(puzzle, r, c, n)) allowed.push(n);
   }
   numberPopup.innerHTML = '';
-  allowed.forEach(num => {
+  for (let num = 1; num <= 9; num++) {
     const btn = document.createElement('button');
     btn.textContent = num;
+    if (!allowed.includes(num)) btn.disabled = true;
     btn.addEventListener('click', () => {
       input.value = String(num);
       input.dispatchEvent(new Event('input'));
@@ -191,14 +192,26 @@ function showPopup(input, r, c) {
       hidePopup();
     });
     numberPopup.appendChild(btn);
+  }
+  const zeroBtn = document.createElement('button');
+  zeroBtn.textContent = '0';
+  zeroBtn.classList.add('zero');
+  zeroBtn.addEventListener('click', () => {
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    input.focus();
+    hidePopup();
   });
+  numberPopup.appendChild(zeroBtn);
   const rect = input.getBoundingClientRect();
   numberPopup.style.top = rect.bottom + window.scrollY + 'px';
   numberPopup.style.left = rect.left + window.scrollX + 'px';
-  numberPopup.style.display = 'block';
+  numberPopup.style.display = 'grid';
+  requestAnimationFrame(() => numberPopup.classList.add('show'));
 }
 
 function hidePopup() {
+  numberPopup.classList.remove('show');
   numberPopup.style.display = 'none';
   numberPopup.innerHTML = '';
 }

--- a/style.css
+++ b/style.css
@@ -72,16 +72,38 @@ h1 {
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);
   z-index: 100;
+  grid-template-columns: repeat(3, 32px);
+  grid-template-rows: repeat(4, 32px);
+  gap: 4px;
+  transform-origin: top left;
+}
+
+@keyframes popup {
+  from { transform: scale(0.5); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+#number-popup.show {
+  animation: popup 0.2s ease-out;
 }
 
 #number-popup button {
-  width: 24px;
-  height: 24px;
-  margin: 2px;
+  width: 32px;
+  height: 32px;
+  margin: 0;
   background: var(--green);
   color: #fff;
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 16px;
+}
+
+#number-popup button.zero {
+  grid-column: 2 / 3;
+}
+
+#number-popup button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- show full keypad in 3x3 layout with `0` button
- animate keypad popup when focusing an empty cell
- style keypad grid and disable invalid numbers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: remix not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475df45d0883269684f23784d44154