### PR TITLE
Fix popup overflow

### DIFF
--- a/app/components/SudokuBoard.tsx
+++ b/app/components/SudokuBoard.tsx
@@ -66,11 +66,21 @@ export default function SudokuBoard() {
     }
     const rect = input.getBoundingClientRect();
     const parentRect = boardRef.current.getBoundingClientRect();
+    let top = rect.bottom - parentRect.top;
+    let left = rect.left - parentRect.left;
+    const popupWidth = 112;
+    const popupHeight = 148;
+    const maxLeft = parentRect.width - popupWidth;
+    if (left > maxLeft) left = Math.max(0, maxLeft);
+    if (left < 0) left = 0;
+    const maxTop = parentRect.height - popupHeight;
+    if (top > maxTop) top = rect.top - parentRect.top - popupHeight;
+    if (top < 0) top = 0;
     setPopup({
       row,
       col,
-      top: rect.bottom - parentRect.top,
-      left: rect.left - parentRect.left,
+      top,
+      left,
       allowed,
     });
   };

--- a/script.js
+++ b/script.js
@@ -204,9 +204,19 @@ function showPopup(input, r, c) {
   });
   numberPopup.appendChild(zeroBtn);
   const rect = input.getBoundingClientRect();
-  numberPopup.style.top = rect.bottom + window.scrollY + 'px';
-  numberPopup.style.left = rect.left + window.scrollX + 'px';
+  const boardRect = boardElement.getBoundingClientRect();
   numberPopup.style.display = 'grid';
+  let top = rect.bottom + window.scrollY;
+  let left = rect.left + window.scrollX;
+  const popupRect = numberPopup.getBoundingClientRect();
+  const maxLeft = boardRect.right + window.scrollX - popupRect.width;
+  const minLeft = boardRect.left + window.scrollX;
+  if (left > maxLeft) left = Math.max(minLeft, maxLeft);
+  if (left < minLeft) left = minLeft;
+  const maxTop = boardRect.bottom + window.scrollY - popupRect.height;
+  if (top > maxTop) top = rect.top + window.scrollY - popupRect.height;
+  numberPopup.style.top = top + 'px';
+  numberPopup.style.left = left + 'px';
   requestAnimationFrame(() => numberPopup.classList.add('show'));
 }
 


### PR DESCRIPTION
## Summary
- ensure number popup stays within the board in plain JS version
- keep popup inside the board bounds in React version

## Testing
- `npm run build` *(fails: remix not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35ab008c8326af892d088e423dfa