### PR TITLE
Enhance Sudoku UI and features

### DIFF
--- a/app/components/SudokuBoard.tsx
+++ b/app/components/SudokuBoard.tsx
@@ -2,9 +2,9 @@ import { useEffect, useRef, useState } from "react";
 import type { Board } from "../utils/sudoku";
 import { generatePuzzle, isSolved, isValidPlacement } from "../utils/sudoku";
 
-const animals = ["🐱","🐶","🐭","🐹","🐰","🦊","🐻","🐼","🐨","🐯"];
-
 export default function SudokuBoard() {
+  const [level, setLevel] = useState(1);
+
   const [puzzle, setPuzzle] = useState<Board | null>(null);
   const [message, setMessage] = useState("");
   const [time, setTime] = useState(0);
@@ -21,6 +21,13 @@ export default function SudokuBoard() {
     if (timerRef.current) return;
     setRunning(true);
     timerRef.current = setInterval(() => setTime((t) => t + 1), 1000);
+  };
+
+  const formatTime = (secs: number) => {
+    const h = String(Math.floor(secs / 3600)).padStart(2, "0");
+    const m = String(Math.floor((secs % 3600) / 60)).padStart(2, "0");
+    const s = String(secs % 60).padStart(2, "0");
+    return `${h}:${m}:${s}`;
   };
 
   const stopTimer = () => {
@@ -40,6 +47,15 @@ export default function SudokuBoard() {
     setTime(0);
   };
 
+  const getBorderClasses = (r: number, c: number) => {
+    const classes = ["border", "border-gray-300"];
+    if (r % 3 === 0) classes.push("border-t-2");
+    if ((r + 1) % 3 === 0) classes.push("border-b-2");
+    if (c % 3 === 0) classes.push("border-l-2");
+    if ((c + 1) % 3 === 0) classes.push("border-r-2");
+    return classes.join(" ");
+  };
+
   const updateCell = (row: number, col: number, value: string) => {
     if (!puzzle) return;
     const num = parseInt(value);
@@ -48,7 +64,7 @@ export default function SudokuBoard() {
     setPuzzle(next);
     if (!running) startTimer();
     if (isSolved(next)) {
-      setMessage("완성! 축하합니다!");
+      setMessage("Puzzle solved! Congratulations!");
       stopTimer();
     }
   };
@@ -97,12 +113,13 @@ export default function SudokuBoard() {
   const checkBoard = () => {
     if (!puzzle) return;
     if (isSolved(puzzle)) {
-      setMessage("완성! 축하합니다!");
+      setMessage("Puzzle solved! Congratulations!");
       stopTimer();
-    } else setMessage("아직 완성되지 않았어요.");
+    } else setMessage("Not solved yet.");
   };
 
   useEffect(() => {
+    startGame(level);
     return () => {
       stopTimer();
     };
@@ -110,42 +127,45 @@ export default function SudokuBoard() {
 
   return (
     <div className="flex flex-col items-center space-y-4 py-6 text-center">
-      <h1 className="text-2xl font-bold">귀여운 스도쿠</h1>
-      <p className="font-bold">시간: {time}초</p>
-      <div>
-        <p>난이도를 선택하세요:</p>
-        <div className="flex flex-wrap justify-center gap-1 mt-1">
-          {animals.map((a, i) => (
-            <button
-              key={i}
-              title={`난이도 ${i + 1}`}
-              className="px-2 py-1 bg-green-600 text-white rounded"
-              onClick={() => startGame(i + 1)}
-            >
-              {a}
-            </button>
-          ))}
-        </div>
+      <h1 className="text-2xl font-bold">Cute Sudoku</h1>
+      <p className="font-bold">Time: {formatTime(time)}</p>
+      <div className="flex flex-col items-center">
+        <label htmlFor="level">Difficulty: {level}</label>
+        <input
+          id="level"
+          type="range"
+          min="1"
+          max="10"
+          value={level}
+          onChange={(e) => {
+            const lvl = parseInt(e.target.value);
+            setLevel(lvl);
+            startGame(lvl);
+          }}
+        />
       </div>
       {puzzle && (
         <> 
           <div
             ref={boardRef}
-            className="grid grid-cols-9 gap-1 mt-4 relative"
+            className="grid grid-cols-9 gap-0 mt-4 relative"
           >
             {puzzle.map((row, r) =>
               row.map((cell, c) =>
                 cell !== 0 ? (
                   <div
                     key={`${r}-${c}`}
-                    className="w-8 h-8 flex items-center justify-center border bg-gray-100 font-bold"
+                    className={`w-8 h-8 flex items-center justify-center bg-gray-100 font-bold ${getBorderClasses(
+                      r,
+                      c
+                    )}`}
                   >
                     {cell}
                   </div>
                 ) : (
                   <input
                     key={`${r}-${c}`}
-                    className="w-8 h-8 text-center border"
+                    className={`w-8 h-8 text-center ${getBorderClasses(r, c)}`}
                     maxLength={1}
                     value={cell === 0 ? "" : cell}
                     onChange={(e) =>
@@ -187,7 +207,7 @@ export default function SudokuBoard() {
             className="mt-4 px-4 py-2 bg-green-600 text-white rounded"
             onClick={checkBoard}
           >
-            정답 확인
+            Check Answer
           </button>
         </>
       )}

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,15 +7,15 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>귀여운 스도쿠</h1>
+  <h1>Cute Sudoku</h1>
   <div id="difficulty">
-    <p>난이도를 선택하세요:</p>
-    <div id="characters"></div>
+    <label for="level">Difficulty: <span id="level-display">1</span></label>
+    <input type="range" id="level" min="1" max="10" value="1">
   </div>
   <div id="board"></div>
   <div id="number-popup"></div>
-  <p id="timer">시간: <span id="time">0</span>초</p>
-  <button id="check">정답 확인</button>
+  <p id="timer">Time: <span id="time">00:00:00</span></p>
+  <button id="check">Check Answer</button>
   <p id="message"></p>
 <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const boardElement = document.getElementById('board');
 const messageElement = document.getElementById('message');
-const charactersElement = document.getElementById('characters');
+const levelSlider = document.getElementById('level');
+const levelDisplay = document.getElementById('level-display');
 const checkButton = document.getElementById('check');
 const timerElement = document.getElementById('time');
 const numberPopup = document.getElementById('number-popup');
@@ -10,15 +11,10 @@ let startTime = 0;
 let timerInterval = null;
 let activeInput = null;
 
-const animals = ['🐱','🐶','🐭','🐹','🐰','🦊','🐻','🐼','🐨','🐯'];
 
-// Create difficulty buttons with cute characters
-animals.forEach((animal, index) => {
-  const btn = document.createElement('button');
-  btn.textContent = animal;
-  btn.title = `난이도 ${index + 1}`;
-  btn.addEventListener('click', () => startGame(index + 1));
-  charactersElement.appendChild(btn);
+levelSlider.addEventListener('input', () => {
+  levelDisplay.textContent = levelSlider.value;
+  startGame(parseInt(levelSlider.value));
 });
 
 let solution = [];
@@ -33,7 +29,7 @@ function startGame(level) {
   hidePopup();
   timerStarted = false;
   clearInterval(timerInterval);
-  timerElement.textContent = '0';
+  timerElement.textContent = formatTime(0);
 }
 
 function generateBoard() {
@@ -105,7 +101,7 @@ function renderBoard(data) {
           puzzle[r][c] = isNaN(val) ? null : val;
           if (!timerStarted) startTimer();
           if (isSolved(puzzle)) {
-            messageElement.textContent = '완성! 축하합니다!';
+            messageElement.textContent = 'Puzzle solved! Congratulations!';
             stopTimer();
           }
         });
@@ -133,10 +129,10 @@ function checkBoard() {
   });
 
   if (isSolved(puzzle)) {
-    messageElement.textContent = '완성! 축하합니다!';
+    messageElement.textContent = 'Puzzle solved! Congratulations!';
     stopTimer();
   } else {
-    messageElement.textContent = '아직 완성되지 않았어요.';
+    messageElement.textContent = 'Not solved yet.';
   }
 }
 
@@ -161,12 +157,19 @@ function isValid(board, row, col, num) {
   return true;
 }
 
+function formatTime(secs) {
+  const h = String(Math.floor(secs / 3600)).padStart(2, '0');
+  const m = String(Math.floor((secs % 3600) / 60)).padStart(2, '0');
+  const s = String(secs % 60).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
 function startTimer() {
   timerStarted = true;
   startTime = Date.now();
   timerInterval = setInterval(() => {
     const secs = Math.floor((Date.now() - startTime) / 1000);
-    timerElement.textContent = String(secs);
+    timerElement.textContent = formatTime(secs);
   }, 1000);
 }
 
@@ -227,3 +230,4 @@ function hidePopup() {
 }
 
 checkButton.addEventListener('click', checkBoard);
+startGame(parseInt(levelSlider.value));

--- a/style.css
+++ b/style.css
@@ -12,22 +12,16 @@ body {
 h1 {
   color: var(--dark-green);
 }
-#characters button {
-  font-size: 24px;
-  background: var(--green);
-  color: #fff;
-  border: none;
+#difficulty input[type="range"] {
+  width: 200px;
   margin: 4px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  cursor: pointer;
 }
 #board {
   margin: 20px auto;
   display: grid;
   grid-template-columns: repeat(9, 40px);
   grid-template-rows: repeat(9, 40px);
-  gap: 2px;
+  gap: 0;
   width: fit-content;
   position: relative;
 }
@@ -39,6 +33,26 @@ h1 {
   font-size: 20px;
   border: 1px solid var(--dark-green);
   background: #fff;
+}
+.cell:nth-child(9n+1),
+.cell:nth-child(9n+4),
+.cell:nth-child(9n+7) {
+  border-left: 2px solid var(--dark-green);
+}
+.cell:nth-child(9n+3),
+.cell:nth-child(9n+6),
+.cell:nth-child(9n) {
+  border-right: 2px solid var(--dark-green);
+}
+.cell:nth-child(-n+9),
+.cell:nth-child(n+28):nth-child(-n+36),
+.cell:nth-child(n+55):nth-child(-n+63) {
+  border-top: 2px solid var(--dark-green);
+}
+.cell:nth-child(n+19):nth-child(-n+27),
+.cell:nth-child(n+46):nth-child(-n+54),
+.cell:nth-child(n+73) {
+  border-bottom: 2px solid var(--dark-green);
 }
 .cell.prefilled {
   background: var(--beige);


### PR DESCRIPTION
## Summary
- switch text to English
- add difficulty slider
- draw thick borders for 3x3 blocks
- show timer in `hh:mm:ss` format

## Testing
- `npm run build` *(fails: remix not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1b3b31e48326a64a210448f7de71