### PR TITLE
Allow zero input, add Inter font, and modernize UI

### DIFF
--- a/app/components/SudokuBoard.tsx
+++ b/app/components/SudokuBoard.tsx
@@ -61,7 +61,7 @@ export default function SudokuBoard() {
     if (!puzzle) return;
     const num = parseInt(value);
     const next = puzzle.map((r) => r.slice());
-    next[row][col] = isNaN(num) ? 0 : num;
+    next[row][col] = isNaN(num) || num === 0 ? 0 : num;
     setPuzzle(next);
     if (!running) startTimer();
     if (isSolved(next)) {
@@ -134,7 +134,7 @@ export default function SudokuBoard() {
   }, []);
 
   return (
-    <div className="flex flex-col items-center space-y-4 py-6 text-center">
+    <div className="flex flex-col items-center space-y-4 py-6 text-center font-sans">
       <h1 className="text-2xl font-bold">Cute Sudoku</h1>
       <p className="font-bold">Time: {formatTime(time)}</p>
       <div className="flex flex-col items-center">
@@ -156,14 +156,14 @@ export default function SudokuBoard() {
         <> 
           <div
             ref={boardRef}
-            className="grid grid-cols-9 gap-0 mt-4 relative"
+            className="grid grid-cols-9 gap-0 mt-4 relative rounded shadow-lg bg-white"
           >
             {puzzle.map((row, r) =>
               row.map((cell, c) =>
                 cell !== 0 ? (
                   <div
                     key={`${r}-${c}`}
-                    className={`w-8 h-8 flex items-center justify-center bg-gray-100 font-bold ${getBorderClasses(
+                    className={`w-8 h-8 flex items-center justify-center bg-gray-100 font-semibold ${getBorderClasses(
                       r,
                       c
                     )}`}
@@ -173,11 +173,15 @@ export default function SudokuBoard() {
                 ) : (
                   <input
                     key={`${r}-${c}`}
-                    className={`w-8 h-8 text-center ${getBorderClasses(r, c)}`}
+                    className={`w-8 h-8 text-center outline-none ${getBorderClasses(r, c)}`}
                     maxLength={1}
                     value={cell === 0 ? "" : cell}
                     onChange={(e) =>
-                      updateCell(r, c, e.target.value.replace(/[^1-9]/g, ""))
+                      updateCell(
+                        r,
+                        c,
+                        e.target.value.replace(/[^0-9]/g, "").replace(/^0$/, "")
+                      )
                     }
                     onFocus={(e) => showPopup(r, c, e.currentTarget)}
                     onBlur={() => {
@@ -195,7 +199,7 @@ export default function SudokuBoard() {
                 {Array.from({ length: 9 }, (_, i) => i + 1).map((n) => (
                   <button
                     key={n}
-                    className="w-8 h-8 text-sm rounded bg-green-600 text-white disabled:bg-gray-300"
+                    className="w-8 h-8 text-sm rounded bg-indigo-600 text-white disabled:bg-gray-300"
                     onMouseDown={(e) => e.preventDefault()}
                     onClick={() => selectNumber(n)}
                     disabled={!popup.allowed.includes(n)}
@@ -204,7 +208,7 @@ export default function SudokuBoard() {
                   </button>
                 ))}
                 <button
-                  className="w-8 h-8 text-sm rounded bg-green-600 text-white col-span-3"
+                  className="w-8 h-8 text-sm rounded bg-indigo-600 text-white col-span-3"
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => selectNumber(0)}
                 >
@@ -214,7 +218,7 @@ export default function SudokuBoard() {
             )}
           </div>
           <button
-            className="mt-4 px-4 py-2 bg-green-600 text-white rounded"
+            className="mt-4 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded"
             onClick={checkBoard}
           >
             Check Answer

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -2,7 +2,10 @@ import type { LinksFunction, MetaFunction } from "@remix-run/node";
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 import styles from "./tailwind.css";
 
-export const links: LinksFunction = () => [{ rel: "stylesheet", href: styles }];
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" },
+  { rel: "stylesheet", href: styles },
+];
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1,3 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans;
+    font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Sudoku Game</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/script.js
+++ b/script.js
@@ -97,7 +97,8 @@ function renderBoard(data) {
         input.dataset.row = r;
         input.dataset.col = c;
         input.addEventListener('input', (e) => {
-          e.target.value = e.target.value.replace(/[^1-9]/g, '');
+          e.target.value = e.target.value.replace(/[^0-9]/g, '');
+          if (e.target.value === '0') e.target.value = '';
           const val = parseInt(e.target.value);
           puzzle[r][c] = isNaN(val) ? null : val;
           if (!timerStarted) startTimer();

--- a/style.css
+++ b/style.css
@@ -1,16 +1,17 @@
 :root {
-  --beige: #f5f5dc;
-  --green: #6b8e23;
-  --dark-green: #556b2f;
+  --bg: #f3f4f6;
+  --primary: #6366f1;
+  --primary-dark: #4f46e5;
+  --text: #374151;
 }
 body {
-  font-family: sans-serif;
+  font-family: 'Inter', sans-serif;
   text-align: center;
-  background: var(--beige);
-  color: var(--dark-green);
+  background: var(--bg);
+  color: var(--text);
 }
 h1 {
-  color: var(--dark-green);
+  color: var(--primary-dark);
 }
 #difficulty input[type="range"] {
   width: 200px;
@@ -24,6 +25,9 @@ h1 {
   gap: 0;
   width: fit-content;
   position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 .cell {
   width: 40px;
@@ -31,41 +35,51 @@ h1 {
   text-align: center;
   line-height: 40px;
   font-size: 20px;
-  border: 1px solid var(--dark-green);
+  border: 1px solid var(--primary-dark);
   background: #fff;
+  transition: background 0.2s;
+  user-select: none;
 }
 .cell:nth-child(9n+1),
 .cell:nth-child(9n+4),
 .cell:nth-child(9n+7) {
-  border-left: 2px solid var(--dark-green);
+  border-left: 2px solid var(--primary-dark);
 }
 .cell:nth-child(9n+3),
 .cell:nth-child(9n+6),
 .cell:nth-child(9n) {
-  border-right: 2px solid var(--dark-green);
+  border-right: 2px solid var(--primary-dark);
 }
 .cell:nth-child(-n+9),
 .cell:nth-child(n+28):nth-child(-n+36),
 .cell:nth-child(n+55):nth-child(-n+63) {
-  border-top: 2px solid var(--dark-green);
+  border-top: 2px solid var(--primary-dark);
 }
 .cell:nth-child(n+19):nth-child(-n+27),
 .cell:nth-child(n+46):nth-child(-n+54),
 .cell:nth-child(n+73) {
-  border-bottom: 2px solid var(--dark-green);
+  border-bottom: 2px solid var(--primary-dark);
 }
 .cell.prefilled {
-  background: var(--beige);
+  background: var(--bg);
   font-weight: bold;
 }
+
+.cell input:focus {
+  outline: 2px solid var(--primary);
+}
 #check {
-  background: var(--green);
+  background: var(--primary);
   color: #fff;
   border: none;
   padding: 8px 16px;
   font-size: 16px;
   border-radius: 8px;
   cursor: pointer;
+  transition: background 0.2s;
+}
+#check:hover {
+  background: var(--primary-dark);
 }
 #message {
   margin-top: 10px;
@@ -81,7 +95,7 @@ h1 {
   position: absolute;
   display: none;
   background: #fff;
-  border: 1px solid var(--dark-green);
+  border: 1px solid var(--primary-dark);
   padding: 4px;
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);
@@ -105,7 +119,7 @@ h1 {
   width: 32px;
   height: 32px;
   margin: 0;
-  background: var(--green);
+  background: var(--primary);
   color: #fff;
   border: none;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- permit 0 input to clear cells
- use Inter font across the app
- refresh CSS with trendy colors and styling
- upgrade Remix board and popup styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d1ec99e1c8326b2bbf28556b07f6e