### PR TITLE
Fix zero entry display

### DIFF
--- a/app/components/SudokuBoard.tsx
+++ b/app/components/SudokuBoard.tsx
@@ -61,7 +61,7 @@ export default function SudokuBoard() {
     if (!puzzle) return;
     const num = parseInt(value);
     const next = puzzle.map((r) => r.slice());
-    next[row][col] = isNaN(num) || num === 0 ? 0 : num;
+    next[row][col] = isNaN(num) ? 0 : num;
     setPuzzle(next);
     if (!running) startTimer();
     if (isSolved(next)) {
@@ -113,7 +113,7 @@ export default function SudokuBoard() {
 
   const selectNumber = (num: number) => {
     if (!popup) return;
-    updateCell(popup.row, popup.col, num === 0 ? "" : String(num));
+    updateCell(popup.row, popup.col, String(num));
     activeInputRef.current?.focus();
     hidePopup();
   };
@@ -175,12 +175,12 @@ export default function SudokuBoard() {
                     key={`${r}-${c}`}
                     className={`w-8 h-8 text-center outline-none ${getBorderClasses(r, c)}`}
                     maxLength={1}
-                    value={cell === 0 ? "" : cell}
+                    value={cell === 0 ? "0" : cell}
                     onChange={(e) =>
                       updateCell(
                         r,
                         c,
-                        e.target.value.replace(/[^0-9]/g, "").replace(/^0$/, "")
+                        e.target.value.replace(/[^0-9]/g, "")
                       )
                     }
                     onFocus={(e) => showPopup(r, c, e.currentTarget)}

--- a/script.js
+++ b/script.js
@@ -98,7 +98,6 @@ function renderBoard(data) {
         input.dataset.col = c;
         input.addEventListener('input', (e) => {
           e.target.value = e.target.value.replace(/[^0-9]/g, '');
-          if (e.target.value === '0') e.target.value = '';
           const val = parseInt(e.target.value);
           puzzle[r][c] = isNaN(val) ? null : val;
           if (!timerStarted) startTimer();
@@ -206,7 +205,7 @@ function showPopup(input, r, c) {
   zeroBtn.textContent = '0';
   zeroBtn.classList.add('zero');
   zeroBtn.addEventListener('click', () => {
-    input.value = '';
+    input.value = '0';
     input.dispatchEvent(new Event('input'));
     input.focus();
     hidePopup();


### PR DESCRIPTION
## Summary
- allow entering '0' in vanilla JS version
- let zero be shown when selected in the popup
- permit zero input in the Remix version and show it in the UI

## Testing
- `npm run build` *(fails: remix not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d201996a0832680345deaac26ebcd