### PR TITLE
Enhance SEO metadata

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,8 +9,14 @@ export const links: LinksFunction = () => [
 
 export const meta: MetaFunction = () => ({
   charset: "utf-8",
-  title: "Sudoku",
+  title: "Cute Sudoku",
   viewport: "width=device-width,initial-scale=1",
+  description:
+    "Play a fun Sudoku puzzle built with Remix and Tailwind CSS. Track your time and improve your skills.",
+  keywords: "sudoku, puzzle game, remix, react, tailwind",
+  "og:title": "Cute Sudoku",
+  "og:description":
+    "Interactive Sudoku puzzle built with Remix and Tailwind CSS.",
 });
 
 export default function App() {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Sudoku Game</title>
+<meta name="description" content="Play a fun Sudoku puzzle and improve your skills.">
+<meta name="keywords" content="sudoku, puzzle, game, remix">
+<meta property="og:title" content="Cute Sudoku">
+<meta property="og:description" content="Solve Sudoku puzzles online with this interactive game.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add meta description, keywords, and Open Graph tags to static HTML
- expand SEO metadata in Remix root component

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: remix not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb39d4d908326bab44d2be783fa92